### PR TITLE
remove hookName type check

### DIFF
--- a/lua/gcompute/ui/ide/views/hookprofiler.lua
+++ b/lua/gcompute/ui/ide/views/hookprofiler.lua
@@ -48,7 +48,7 @@ function self:ctor (container)
 			return a.HookData.CallCount > b.HookData.CallCount
 		end
 	)
-	
+
 	self.Hooks = {}
 	self.LastSortTime = SysTime ()
 end
@@ -71,10 +71,10 @@ function self:CreateHookData (eventName, hookName)
 	hookData.OriginalHandler = nil
 	hookData.CallCount       = 0
 	hookData.Time            = 0
-	
+
 	hookData.LastFrame       = CurTime ()
 	hookData.LastFrameTime   = 0
-	
+
 	hookData.DeltaFPS        = 0
 	return hookData
 end
@@ -83,31 +83,27 @@ function self:Start ()
 	for eventName, hookTable in pairs (hook.GetTable ()) do
 		self.Hooks [eventName] = self.Hooks [eventName] or {}
 		for hookName, handler in pairs (hookTable) do
-			if type (hookName) == "string" or
-			   type (hookName) == "number" or
-			   hookName:IsValid () then
-				local hookData = self.Hooks [eventName] [hookName] or self:CreateHookData (eventName, hookName)
-				self.Hooks [eventName] [hookName] = hookData
-				hookData.CallCount = 0
-				hookData.Time = 0
-				if not hookData.OriginalHandler then
-					hookData.OriginalHandler = handler
-				end
-				hook.Add (eventName, hookName,
-					function (...)
-						local startTime = SysTime ()
-						hookData.CallCount = hookData.CallCount + 1
-						local a, b, c, d, e, f, g, h = hookData.OriginalHandler (...)
-						hookData.Time = hookData.Time + SysTime () - startTime
-						if CurTime () ~= hookData.LastFrame then
-							hookData.LastFrame = CurTime ()
-							hookData.LastFrameTime = 0
-						end
-						hookData.LastFrameTime = hookData.LastFrameTime + SysTime () - startTime
-						return a, b, c, d, e, f, g, h
-					end
-				)
+			local hookData = self.Hooks [eventName] [hookName] or self:CreateHookData (eventName, hookName)
+			self.Hooks [eventName] [hookName] = hookData
+			hookData.CallCount = 0
+			hookData.Time = 0
+			if not hookData.OriginalHandler then
+				hookData.OriginalHandler = handler
 			end
+			hook.Add (eventName, hookName,
+				function (...)
+					local startTime = SysTime ()
+					hookData.CallCount = hookData.CallCount + 1
+					local a, b, c, d, e, f, g, h = hookData.OriginalHandler (...)
+					hookData.Time = hookData.Time + SysTime () - startTime
+					if CurTime () ~= hookData.LastFrame then
+						hookData.LastFrame = CurTime ()
+						hookData.LastFrameTime = 0
+					end
+					hookData.LastFrameTime = hookData.LastFrameTime + SysTime () - startTime
+					return a, b, c, d, e, f, g, h
+				end
+			)
 		end
 	end
 end
@@ -133,14 +129,14 @@ function self:UpdateHookData (hookData)
 		local listViewItem = self.ListView:AddItem (tostring (hookData))
 		listViewItem:SetText (tostring (hookData.EventName))
 		listViewItem:SetColumnText ("ID", tostring (hookData.HookName))
-		
+
 		listViewItem.HookData = hookData
 		hookData.ListViewItem = listViewItem
 	end
-	
+
 	hookData.ListViewItem:SetColumnText ("Calls", tostring (hookData.CallCount))
 	hookData.ListViewItem:SetColumnText ("Frame Time (ms)", string.format ("%.3f", (hookData.LastFrameTime) * 1000))
-	
+
 	local currentFPS = 1 / FrameTime ()
 	local higherFPS = 1 / (FrameTime () - hookData.LastFrameTime)
 	hookData.DeltaFPS = higherFPS - currentFPS


### PR DESCRIPTION
Some things like to add functions or other weird types as hook names.

This RenderScene one adds a function as the hook name, which doesn't have `IsValid`
https://gitlab.com/metastruct/fast_addons/blob/5fe7c09d73232cb718d0d69cd7fb69f8457074cb/lua/helpers/misc_helpers.lua#L235


```
Player [20][SpiralP] ERR:  
	gcompute/ui/ide/views/hookprofiler.lua:88: attempt to call method 'IsValid' (a nil value)
		 1: Start (self = { GCompute.IDE.ViewTypes.Types.HookProfiler.Constructor: 0x7390d588 }) [gcompute/ui/ide/views/hookprofiler.lua: 88]
		 2: () [gcompute/ui/ide/views/hookprofiler.lua: 15]
		 3: xpcall (GLib.Error) [[C]: -1]
		 4: DispatchEvent (self = { GLib.EventProvider: 0x81d7e230 }, eventName = "Click", { Gooey.ToolbarButton: 0x81d7e058 }) [glib/events/eventprovider.lua: 86]
		 5: (_ = { Gooey.ToolbarButton:
Player [20][SpiralP] ERR: Error in hook Click: Func:(hookprofiler.lua: 14-18 FEnv)!
```

You can diff without whitespace/indentation by using
https://github.com/notcake/gcompute/pull/23/files?w=1
